### PR TITLE
use foundry image on stable version

### DIFF
--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -1,9 +1,9 @@
 services:
   anvil:
-    image: ghcr.io/ensdomains/anvil:next
+    image: ghcr.io/foundry-rs/foundry:stable
     ports:
       - '8545:8545'
-    entrypoint: /bin/sh -c 'anvil --chain-id 1337 --gas-limit 50000000 --timestamp 1640995200 $ANVIL_EXTRA_ARGS'
+    entrypoint: anvil --chain-id 1337 --gas-limit 50000000 --timestamp 1640995200 $ANVIL_EXTRA_ARGS
     environment:
       ANVIL_IP_ADDR: '0.0.0.0'
   graph-node:
@@ -40,7 +40,7 @@ services:
     image: postgres:14-alpine
     ports:
       - '5432:5432'
-    command: ['postgres', '-cshared_preload_libraries=pg_stat_statements']
+    command: [ 'postgres', '-cshared_preload_libraries=pg_stat_statements' ]
     environment:
       POSTGRES_USER: graph-node
       POSTGRES_PASSWORD: let-me-in


### PR DESCRIPTION
now using external foundry image, built by the foundry team which, which includes anvil. stable tag bumps the version to `1.0.0` as well.

there is a very significant perf improvement compared to the currently used anvil version.