### PR TITLE
feat: update to ensindexer with ens-test-env rc, latest ensrainbow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   devnet:
+    container_name: devnet
     image: ghcr.io/ensdomains/namechain:d800b74
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   ensindexer:
     container_name: ensindexer
-    image: ghcr.io/namehash/ensnode/ensindexer:latest
+    image: ghcr.io/namehash/ensnode/ensindexer:0.36.0-rc.1
     pull_policy: always
     ports:
       - "42069:42069"
@@ -33,28 +33,31 @@ services:
       - ensrainbow
     environment:
       PORT: 42069
-      RPC_URL_1337: http://devnet:8545
-      RPC_URL_1: http://devnet:8545
+      RPC_URL_15658733: http://devnet:8545
       ENSNODE_PUBLIC_URL: http://localhost:42069
+      ENSINDEXER_URL: http://localhost:42069
       ENSRAINBOW_URL: http://ensrainbow:3223
-      ENSINDEXER_URL: http://ensindexer:42069
       DATABASE_URL: postgresql://postgres:password@postgres:5432/postgres
       DATABASE_SCHEMA: ens-test-env
-      ENS_DEPLOYMENT_CHAIN: ens-test-env
       NAMESPACE: ens-test-env
       HEAL_REVERSE_ADDRESSES: false
       INDEX_RESOLVER_RECORDS: false
-      LABEL_SET_ID: subgraph
-      LABEL_SET_VERSION: 0
+      REPLACE_UNNORMALIZED: false
       PLUGINS: subgraph
-      DEPLOYMENT_ADDRESSES: '{"LegacyENSRegistry":"0x610178dA211FEF7D417bC0e6FeD39F05609AD788","ENSRegistry":"0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e","BaseRegistrarImplementation":"0xa82fF9aFd8f496c3d6ac40E2a0F282E47488CFc9","NameWrapper":"0x2E2Ed0Cfd3AD2f1d34481277b3204d807Ca2F8c2","UniversalResolver":"0xD84379CEae14AA33C123Af12424A37803F885889","ETHRegistrarController":"0x36b58F5C1969B7b6591D752ea6F5486D069010AB","LegacyETHRegistrarController":"0x5081a39b8A5f0E35a8D959395a630b68B74Dd30f","WrappedETHRegistrarController":"0x253553366Da8546fC250F225fe3d25d0C782303b"}'
+      LABEL_SET_ID: ens-test-env
+      LABEL_SET_VERSION: 0
 
   ensrainbow:
     container_name: ensrainbow
-    image: ghcr.io/namehash/ensnode/ensrainbow-test:latest
+    image: ghcr.io/namehash/ensnode/ensrainbow:latest
     pull_policy: always
     environment:
+      DB_SCHEMA_VERSION: 3
+      LABEL_SET_ID: ens-test-env
+      LABEL_SET_VERSION: 0
       LOG_LEVEL: error
+    tmpfs:
+      - /app/apps/ensrainbow/data
 
   postgres:
     container_name: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,9 +28,12 @@ services:
     ports:
       - "42069:42069"
     depends_on:
-      - postgres
-      - devnet
-      - ensrainbow
+      postgres:
+        condition: service_started
+      ensrainbow:
+        condition: service_healthy
+      devnet:
+        condition: service_started
     environment:
       PORT: 42069
       RPC_URL_15658733: http://devnet:8545
@@ -49,7 +52,7 @@ services:
 
   ensrainbow:
     container_name: ensrainbow
-    image: ghcr.io/namehash/ensnode/ensrainbow:latest
+    image: ghcr.io/namehash/ensnode/ensrainbow:0.36.0-rc.1
     pull_policy: always
     environment:
       DB_SCHEMA_VERSION: 3
@@ -58,6 +61,13 @@ services:
       LOG_LEVEL: error
     tmpfs:
       - /app/apps/ensrainbow/data
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3223/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20m
+      start_interval: 30s
 
   postgres:
     container_name: postgres


### PR DESCRIPTION
- pins the ensindexer/ensrainbow images to a specific version, for stability
  - currently the `0.36.0-rc.1` candidate that includes the deterministic devnet addresses from [this PR](https://github.com/namehash/ensnode/pull/1029)
- updates to latest ensrainbow and specifies the `ens-test-env` labelset — should should dramatically speed up start times
  - adds healthcheck to wait for ensrainbow to download the labelset
  - caches labelset in a tempfs like postgres