### PR TITLE
Updates devnet to `580c60a` and ensnode to `1.15.1`

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -122,8 +122,8 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - ADDRESS_ETH_REGISTRAR=0xb7278a61aa25c888815afc32ad3cc52ff24fe575
-      - ADDRESS_NAME_WRAPPER=0xfd471836031dc5108809d173a067e8486b9047a3
+      - ADDRESS_ETH_REGISTRAR=0x8a791620dd6260079bf849dc5567adc3f2fdc318
+      - ADDRESS_NAME_WRAPPER=0x5081a39b8a5f0e35a8d959395a630b68b74dd30f
       - RPC_PROVIDER=http://devnet:8545
       - SUBGRAPH_URL=http://ensapi:4334/subgraph
 

--- a/compose.yml
+++ b/compose.yml
@@ -30,7 +30,7 @@ services:
       ENSDB_URL: postgresql://postgres:password@ensdb:5432/postgres
       ENSINDEXER_SCHEMA_NAME: ensindexer_temp_ens-test-env
       NAMESPACE: ens-test-env
-      PLUGINS: subgraph,ensv2,protocol-acceleration
+      PLUGINS: subgraph,unigraph,protocol-acceleration
       LABEL_SET_ID: ens-test-env
       LABEL_SET_VERSION: 0
       RPC_URL_15658733: http://devnet:8545

--- a/compose.yml
+++ b/compose.yml
@@ -16,7 +16,7 @@ services:
       start_interval: 1s
 
   ensindexer:
-    image: ghcr.io/namehash/ensnode/ensindexer:1.13.1
+    image: ghcr.io/namehash/ensnode/ensindexer:1.15.1
     pull_policy: always
     depends_on:
       ensdb:
@@ -44,7 +44,7 @@ services:
       start_interval: 1s
 
   ensrainbow:
-    image: ghcr.io/namehash/ensnode/ensrainbow:1.13.1
+    image: ghcr.io/namehash/ensnode/ensrainbow:1.15.1
     pull_policy: always
     environment:
       DB_SCHEMA_VERSION: 3
@@ -62,7 +62,7 @@ services:
       start_interval: 1s
 
   ensapi:
-    image: ghcr.io/namehash/ensnode/ensapi:1.13.1
+    image: ghcr.io/namehash/ensnode/ensapi:1.15.1
     pull_policy: always
     ports:
       - "4334:4334"
@@ -84,7 +84,7 @@ services:
         condition: service_healthy
 
   ensadmin:
-    image: ghcr.io/namehash/ensnode/ensadmin:1.13.1
+    image: ghcr.io/namehash/ensnode/ensadmin:1.15.1
     pull_policy: always
     ports:
       - "4173:4173"

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   devnet:
-    image: ghcr.io/ensdomains/contracts-v2:main-e8696c6
+    image: ghcr.io/ensdomains/contracts-v2:main-580c60a
     command: ./script/runDevnet.ts --testNames
     pull_policy: always
     ports:
@@ -16,19 +16,18 @@ services:
       start_interval: 1s
 
   ensindexer:
-    image: ghcr.io/namehash/ensnode/ensindexer:1.10.1
+    image: ghcr.io/namehash/ensnode/ensindexer:1.11.0
     pull_policy: always
     depends_on:
-      postgres:
+      ensdb:
         condition: service_healthy
       ensrainbow:
         condition: service_healthy
       devnet:
         condition: service_healthy
     environment:
-      ENSINDEXER_URL: http://ensindexer:42069
       ENSRAINBOW_URL: http://ensrainbow:3223
-      ENSDB_URL: postgresql://postgres:password@postgres:5432/postgres
+      ENSDB_URL: postgresql://postgres:password@ensdb:5432/postgres
       ENSINDEXER_SCHEMA_NAME: ensindexer_temp_ens-test-env
       NAMESPACE: ens-test-env
       PLUGINS: subgraph,ensv2,protocol-acceleration
@@ -45,7 +44,7 @@ services:
       start_interval: 1s
 
   ensrainbow:
-    image: ghcr.io/namehash/ensnode/ensrainbow:1.10.1
+    image: ghcr.io/namehash/ensnode/ensrainbow:1.11.0
     pull_policy: always
     environment:
       DB_SCHEMA_VERSION: 3
@@ -57,18 +56,18 @@ services:
     healthcheck:
       test: [ "CMD", "wget", "-q", "--spider", "http://localhost:3223/health" ]
       interval: 30s
-      timeout: 5s
-      retries: 2
+      timeout: 3s
+      retries: 3
       start_period: 2m
       start_interval: 1s
 
   ensapi:
-    image: ghcr.io/namehash/ensnode/ensapi:1.10.1
+    image: ghcr.io/namehash/ensnode/ensapi:1.11.0
     pull_policy: always
     ports:
       - "4334:4334"
     environment:
-      ENSDB_URL: postgresql://postgres:password@postgres:5432/postgres
+      ENSDB_URL: postgresql://postgres:password@ensdb:5432/postgres
       ENSINDEXER_SCHEMA_NAME: ensindexer_temp_ens-test-env
       RPC_URL_15658733: http://devnet:8545
     healthcheck:
@@ -79,24 +78,24 @@ services:
       start_period: 1m
       start_interval: 1s
     depends_on:
-      postgres:
+      ensdb:
         condition: service_healthy
       devnet:
         condition: service_healthy
 
   ensadmin:
-    image: ghcr.io/namehash/ensnode/ensadmin:1.10.1
+    image: ghcr.io/namehash/ensnode/ensadmin:1.11.0
     pull_policy: always
     ports:
       - "4173:4173"
     environment:
       ENSADMIN_PUBLIC_URL: http://localhost:4173
-      NEXT_PUBLIC_DEFAULT_ENSNODE_URLS: http://localhost:4334
+      NEXT_PUBLIC_SERVER_CONNECTION_LIBRARY: http://localhost:4334
     depends_on:
       ensapi:
         condition: service_healthy
 
-  postgres:
+  ensdb:
     restart: always
     image: postgres:17
     environment:

--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       ANVIL_IP_ADDR: "0.0.0.0"
     healthcheck:
-      test: [ "CMD", "curl", "--fail", "-s", "http://localhost:8000/health" ]
+      test: ["CMD", "curl", "--fail", "-s", "http://localhost:8000/health"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -16,7 +16,7 @@ services:
       start_interval: 1s
 
   ensindexer:
-    image: ghcr.io/namehash/ensnode/ensindexer:1.11.0
+    image: ghcr.io/namehash/ensnode/ensindexer:1.13.1
     pull_policy: always
     depends_on:
       ensdb:
@@ -36,7 +36,7 @@ services:
       RPC_URL_15658733: http://devnet:8545
       RPC_URL_15658734: http://devnet:8546
     healthcheck:
-      test: [ "CMD", "curl", "--fail", "-s", "http://localhost:42069/health" ]
+      test: ["CMD", "curl", "--fail", "-s", "http://localhost:42069/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -44,7 +44,7 @@ services:
       start_interval: 1s
 
   ensrainbow:
-    image: ghcr.io/namehash/ensnode/ensrainbow:1.11.0
+    image: ghcr.io/namehash/ensnode/ensrainbow:1.13.1
     pull_policy: always
     environment:
       DB_SCHEMA_VERSION: 3
@@ -54,7 +54,7 @@ services:
     volumes:
       - ensrainbow_data:/app/apps/ensrainbow/data
     healthcheck:
-      test: [ "CMD", "wget", "-q", "--spider", "http://localhost:3223/health" ]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3223/health"]
       interval: 30s
       timeout: 3s
       retries: 3
@@ -62,7 +62,7 @@ services:
       start_interval: 1s
 
   ensapi:
-    image: ghcr.io/namehash/ensnode/ensapi:1.11.0
+    image: ghcr.io/namehash/ensnode/ensapi:1.13.1
     pull_policy: always
     ports:
       - "4334:4334"
@@ -71,7 +71,7 @@ services:
       ENSINDEXER_SCHEMA_NAME: ensindexer_temp_ens-test-env
       RPC_URL_15658733: http://devnet:8545
     healthcheck:
-      test: [ "CMD", "curl", "--fail", "-s", "http://localhost:4334/health" ]
+      test: ["CMD", "curl", "--fail", "-s", "http://localhost:4334/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -84,7 +84,7 @@ services:
         condition: service_healthy
 
   ensadmin:
-    image: ghcr.io/namehash/ensnode/ensadmin:1.11.0
+    image: ghcr.io/namehash/ensnode/ensadmin:1.13.1
     pull_policy: always
     ports:
       - "4173:4173"
@@ -105,7 +105,7 @@ services:
     tmpfs:
       - /var/lib/postgresql/data
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}" ]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,10 @@
 services:
   devnet:
-    image: ghcr.io/ensdomains/namechain:main-9e31679
+    image: ghcr.io/ensdomains/contracts-v2:main-f476641
     command: ./script/runDevnet.ts --testNames
     pull_policy: always
     ports:
-      - "8545:8545" # L1 chain
-      - "8546:8546" # L2 chain
-      - "8547:8547" # Urg
+      - "8545:8545"
     environment:
       ANVIL_IP_ADDR: "0.0.0.0"
     healthcheck:
@@ -18,7 +16,7 @@ services:
       start_interval: 1s
 
   ensindexer:
-    image: ghcr.io/namehash/ensnode/ensindexer:1.5.1
+    image: ghcr.io/namehash/ensnode/ensindexer:preview-feat-ensv2-integration-updates-73796c16
     pull_policy: always
     depends_on:
       postgres:
@@ -47,7 +45,7 @@ services:
       start_interval: 1s
 
   ensrainbow:
-    image: ghcr.io/namehash/ensnode/ensrainbow:1.5.1
+    image: ghcr.io/namehash/ensnode/ensrainbow:preview-feat-ensv2-integration-updates-73796c16
     pull_policy: always
     environment:
       DB_SCHEMA_VERSION: 3
@@ -65,7 +63,7 @@ services:
       start_interval: 1s
 
   ensapi:
-    image: ghcr.io/namehash/ensnode/ensapi:1.5.1
+    image: ghcr.io/namehash/ensnode/ensapi:preview-feat-ensv2-integration-updates-73796c16
     pull_policy: always
     ports:
       - "4334:4334"
@@ -81,7 +79,7 @@ services:
       RPC_URL_15658734: http://devnet:8546
 
   ensadmin:
-    image: ghcr.io/namehash/ensnode/ensadmin:1.5.1
+    image: ghcr.io/namehash/ensnode/ensadmin:preview-feat-ensv2-integration-updates-73796c16
     pull_policy: always
     ports:
       - "4173:4173"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   devnet:
-    image: ghcr.io/ensdomains/contracts-v2:main-4ac5517
+    image: ghcr.io/ensdomains/contracts-v2:main-e8696c6
     command: ./script/runDevnet.ts --testNames
     pull_policy: always
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       ANVIL_IP_ADDR: "0.0.0.0"
     healthcheck:
-      test: ["CMD", "curl", "--fail", "-s", "http://localhost:8000/health"]
+      test: [ "CMD", "curl", "--fail", "-s", "http://localhost:8000/health" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -16,20 +16,20 @@ services:
       start_interval: 1s
 
   ensindexer:
-    image: ghcr.io/namehash/ensnode/ensindexer:preview-feat-update-devnet-addresses
+    image: ghcr.io/namehash/ensnode/ensindexer:1.10.0
     pull_policy: always
     depends_on:
       postgres:
-        condition: service_started
+        condition: service_healthy
       ensrainbow:
         condition: service_healthy
       devnet:
-        condition: service_started
+        condition: service_healthy
     environment:
       ENSINDEXER_URL: http://ensindexer:42069
       ENSRAINBOW_URL: http://ensrainbow:3223
-      DATABASE_URL: postgresql://postgres:password@postgres:5432/postgres
-      DATABASE_SCHEMA: ens-test-env
+      ENSDB_URL: postgresql://postgres:password@postgres:5432/postgres
+      ENSINDEXER_SCHEMA_NAME: ensindexer_temp_ens-test-env
       NAMESPACE: ens-test-env
       PLUGINS: ensv2,protocol-acceleration
       LABEL_SET_ID: ens-test-env
@@ -37,7 +37,7 @@ services:
       RPC_URL_15658733: http://devnet:8545
       RPC_URL_15658734: http://devnet:8546
     healthcheck:
-      test: ["CMD", "curl", "--fail", "-s", "http://localhost:42069/health"]
+      test: [ "CMD", "curl", "--fail", "-s", "http://localhost:42069/health" ]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -45,7 +45,7 @@ services:
       start_interval: 1s
 
   ensrainbow:
-    image: ghcr.io/namehash/ensnode/ensrainbow:preview-feat-update-devnet-addresses
+    image: ghcr.io/namehash/ensnode/ensrainbow:1.10.0
     pull_policy: always
     environment:
       DB_SCHEMA_VERSION: 3
@@ -55,7 +55,7 @@ services:
     volumes:
       - ensrainbow_data:/app/apps/ensrainbow/data
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3223/health"]
+      test: [ "CMD", "wget", "-q", "--spider", "http://localhost:3223/health" ]
       interval: 30s
       timeout: 5s
       retries: 2
@@ -63,23 +63,29 @@ services:
       start_interval: 1s
 
   ensapi:
-    image: ghcr.io/namehash/ensnode/ensapi:preview-feat-update-devnet-addresses
+    image: ghcr.io/namehash/ensnode/ensapi:1.10.0
     pull_policy: always
     ports:
       - "4334:4334"
+    environment:
+      ENSDB_URL: postgresql://postgres:password@postgres:5432/postgres
+      ENSINDEXER_SCHEMA_NAME: ensindexer_temp_ens-test-env
+      RPC_URL_15658733: http://devnet:8545
+    healthcheck:
+      test: [ "CMD", "curl", "--fail", "-s", "http://localhost:4334/health" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 1m
+      start_interval: 1s
     depends_on:
       postgres:
-        condition: service_started
-      ensindexer:
         condition: service_healthy
-    environment:
-      ENSINDEXER_URL: http://ensindexer:42069
-      DATABASE_URL: postgresql://postgres:password@postgres:5432/postgres
-      RPC_URL_15658733: http://devnet:8545
-      RPC_URL_15658734: http://devnet:8546
+      devnet:
+        condition: service_healthy
 
   ensadmin:
-    image: ghcr.io/namehash/ensnode/ensadmin:preview-feat-update-devnet-addresses
+    image: ghcr.io/namehash/ensnode/ensadmin:1.10.0
     pull_policy: always
     ports:
       - "4173:4173"
@@ -87,29 +93,39 @@ services:
       ENSADMIN_PUBLIC_URL: http://localhost:4173
       NEXT_PUBLIC_DEFAULT_ENSNODE_URLS: http://localhost:4334
     depends_on:
-      - ensapi
+      ensapi:
+        condition: service_healthy
 
   postgres:
     restart: always
     image: postgres:17
     environment:
+      POSTGRES_DB: postgres
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
     tmpfs:
       - /var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   metadata:
     image: ghcr.io/ensdomains/ens-metadata-service:latest
     depends_on:
-      - devnet
-      - ensindexer
+      devnet:
+        condition: service_healthy
+      ensindexer:
+        condition: service_healthy
     ports:
       - "8080:8080"
     environment:
       - ADDRESS_ETH_REGISTRAR=0xb7278a61aa25c888815afc32ad3cc52ff24fe575
       - ADDRESS_NAME_WRAPPER=0xfd471836031dc5108809d173a067e8486b9047a3
       - RPC_PROVIDER=http://devnet:8545
-      - SUBGRAPH_URL=http://ensindexer:42069/subgraph
+      - SUBGRAPH_URL=http://ensapi:4334/subgraph
 
 volumes:
   ensrainbow_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       start_interval: 1s
 
   ensindexer:
-    image: ghcr.io/namehash/ensnode/ensindexer:1.10.0
+    image: ghcr.io/namehash/ensnode/ensindexer:1.10.1
     pull_policy: always
     depends_on:
       postgres:
@@ -45,7 +45,7 @@ services:
       start_interval: 1s
 
   ensrainbow:
-    image: ghcr.io/namehash/ensnode/ensrainbow:1.10.0
+    image: ghcr.io/namehash/ensnode/ensrainbow:1.10.1
     pull_policy: always
     environment:
       DB_SCHEMA_VERSION: 3
@@ -63,7 +63,7 @@ services:
       start_interval: 1s
 
   ensapi:
-    image: ghcr.io/namehash/ensnode/ensapi:1.10.0
+    image: ghcr.io/namehash/ensnode/ensapi:1.10.1
     pull_policy: always
     ports:
       - "4334:4334"
@@ -85,7 +85,7 @@ services:
         condition: service_healthy
 
   ensadmin:
-    image: ghcr.io/namehash/ensnode/ensadmin:1.10.0
+    image: ghcr.io/namehash/ensnode/ensadmin:1.10.1
     pull_policy: always
     ports:
       - "4173:4173"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   devnet:
-    image: ghcr.io/ensdomains/contracts-v2:main-f476641
+    image: ghcr.io/ensdomains/contracts-v2:main-4ac5517
     command: ./script/runDevnet.ts --testNames
     pull_policy: always
     ports:
@@ -16,7 +16,7 @@ services:
       start_interval: 1s
 
   ensindexer:
-    image: ghcr.io/namehash/ensnode/ensindexer:preview-feat-ensv2-integration-updates-73796c16
+    image: ghcr.io/namehash/ensnode/ensindexer:preview-feat-update-devnet-addresses
     pull_policy: always
     depends_on:
       postgres:
@@ -45,7 +45,7 @@ services:
       start_interval: 1s
 
   ensrainbow:
-    image: ghcr.io/namehash/ensnode/ensrainbow:preview-feat-ensv2-integration-updates-73796c16
+    image: ghcr.io/namehash/ensnode/ensrainbow:preview-feat-update-devnet-addresses
     pull_policy: always
     environment:
       DB_SCHEMA_VERSION: 3
@@ -63,7 +63,7 @@ services:
       start_interval: 1s
 
   ensapi:
-    image: ghcr.io/namehash/ensnode/ensapi:preview-feat-ensv2-integration-updates-73796c16
+    image: ghcr.io/namehash/ensnode/ensapi:preview-feat-update-devnet-addresses
     pull_policy: always
     ports:
       - "4334:4334"
@@ -79,7 +79,7 @@ services:
       RPC_URL_15658734: http://devnet:8546
 
   ensadmin:
-    image: ghcr.io/namehash/ensnode/ensadmin:preview-feat-ensv2-integration-updates-73796c16
+    image: ghcr.io/namehash/ensnode/ensadmin:preview-feat-update-devnet-addresses
     pull_policy: always
     ports:
       - "4173:4173"


### PR DESCRIPTION
- devnet to `580c60a`
- ensnode to `1.15.1`
  - associated configuration updated
- postgres healthcheck added
- `PLUGINS` updated to be `subgraph,ensv2,protocol-acceleration` — the `/subgraph` AND the `/api/omnigraph` endpoints are both available.
- `LABEL_SET` kept as `ens-test-env`
---

i suggest an env override within the ensjs test suite if you'd like to change the env variables, since the ens-test-env should stay as a minimal ens-test-env-focused utility